### PR TITLE
using logarithm of the integrand #13

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Given a Bayesian problem `p(x|y) = p(y|x) p_0(x) / p(y)` you can estimate `p(y)`
 using BayesianQuadrature
 using Distributions
 using KernelFunctions
-prior = MvNormal(ones(2)) # As for now the prior must be a MvNormal
-integrand(x) = pdf(MvNormal(0.5 * ones(2)), x) # Integrand, the likelihood function typically
-model = BayesModel(prior, integrand) # Combine both to create the model
+p_0 = MvNormal(ones(2)) # As for now the prior must be a MvNormal
+log_f(x) = logpdf(MvNormal(0.5 * ones(2)), x) # The logarithm of the Integrand log_f, the log-likelihood function typically
+model = BayesModel(p_0, log_f) # Combine both to create the model
 bquad = BayesQuad(SEKernel(); l=0.1, σ=1.0) # Will simply approximate p(y|x) with a GP (only works with SEKernel for now
 sampler = PriorSampling() # Will sample from the prior p_0
 p_I, _ = bquad(model, sampler; nsamples=100) # Returns a Normal distribution

--- a/src/BayesianQuadrature.jl
+++ b/src/BayesianQuadrature.jl
@@ -8,7 +8,7 @@ using PDMats
 using Random
 
 export BayesQuad, PriorSampling, BayesModel
-export prior, integrand, logprior, logjoint
+export prior, integrand, logintegrand, logprior, logjoint
 
 abstract type AbstractBayesQuad end
 abstract type AbstractBayesQuadModel{Tp, Ti} <: AbstractMCMC.AbstractModel end

--- a/src/models.jl
+++ b/src/models.jl
@@ -1,18 +1,19 @@
 
 prior(m::AbstractBayesQuadModel) = m.prior
-integrand(m::AbstractBayesQuadModel) = m.integrand
+logintegrand(m::AbstractBayesQuadModel) = m.logintegrand
+integrand(m::AbstractBayesQuadModel) = x->exp(logintegrand(m)(x))
 logprior(m::AbstractBayesQuadModel) = x->logpdf(prior(m), x)
-logjoint(m::AbstractBayesQuadModel) = x->logprior(m)(x) + log(integrand(m)(x))
+logjoint(m::AbstractBayesQuadModel) = x->logprior(m)(x) + logintegrand(m)(x)
 
 """
-    BayesModel(prior, integrand)
+    BayesModel(prior, logintegrand)
 
 Model inheriting from AbstractMCMC.AbstractModel.
 `prior` should be a multivariate distribution from `Distributions.jl`
 at the moment `prior` has to be a `MvNormal` but this will improved in a later version
-`integrand` should be the function to integrate.
+`logintegrand` should be the logarithm function to integrate.
 """
 struct BayesModel{Tp,Ti} <: AbstractBayesQuadModel{Tp,Ti}
     prior::Tp
-    integrand::Ti
+    logintegrand::Ti
 end

--- a/src/models.jl
+++ b/src/models.jl
@@ -11,7 +11,7 @@ logjoint(m::AbstractBayesQuadModel) = x->logprior(m)(x) + logintegrand(m)(x)
 Model inheriting from AbstractMCMC.AbstractModel.
 `prior` should be a multivariate distribution from `Distributions.jl`
 at the moment `prior` has to be a `MvNormal` but this will improved in a later version
-`logintegrand` should be the logarithm function to integrate.
+`logintegrand` should be the log of the function to integrate.
 """
 struct BayesModel{Tp,Ti} <: AbstractBayesQuadModel{Tp,Ti}
     prior::Tp

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -3,8 +3,8 @@
     D = 5
     prior = MvNormal(0.5 * ones(D))
     likelihood = MvNormal(7.0 * ones(D))
-    integrand = x->pdf(likelihood, x)
-    m = BayesModel(prior, integrand)
+    logintegrand = x->logpdf(likelihood, x)
+    m = BayesModel(prior, logintegrand)
     s = PriorSampling()
     bquad = BayesQuad(transform(SEKernel(), 0.1))
     pZ, x  = bquad(m, s; nsamples=100)

--- a/test/models.jl
+++ b/test/models.jl
@@ -3,12 +3,13 @@
     D = 5
     p0 = MvNormal(0.5 * ones(D))
     likelihood = MvNormal(7.0 * ones(D))
-    f = x->pdf(likelihood, x)
-    m = BayesModel(p0, f)  
+    logf = x->logpdf(likelihood, x)
+    m = BayesModel(p0, logf)  
 
     x1 = randn(rng,Float64,D)
+    @test integrand(m)(x1) ≈ pdf(likelihood, x1)
     @test logprior(m)(x1) ≈ logpdf(p0,x1)
     @test logjoint(m)(x1) ≈ logpdf(p0,x1) + logpdf(likelihood,x1)
     @test prior(m) == p0
-    @test integrand(m) == f
+    @test logintegrand(m) == logf
 end


### PR DESCRIPTION
I directly implemented it the way that we use the log integrand directly in the `BayesModel`. Maybe a type for the integrand would be more general similar to the distributions in `Distributions.jl`.