### PR TITLE
Adding the Log transformation approach from Osborne et al. 2012

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Theo Galy-Fajou <theo.galyfajou@gmail.com> and contributors"]
 version = "0.1.0"
 
 [deps]
+AbstractGPs = "99985d1d-32ba-4be9-9821-2ec096f28918"
 AbstractMCMC = "80f14c24-f653-4e6a-9b94-39d6b0f70001"
 Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 KernelFunctions = "ec8451be-7e33-11e9-00cf-bbf324bd1392"

--- a/src/BayesianQuadrature.jl
+++ b/src/BayesianQuadrature.jl
@@ -1,5 +1,6 @@
 module BayesianQuadrature
 
+using AbstractGPs
 using AbstractMCMC
 using Distributions
 using KernelFunctions
@@ -7,10 +8,11 @@ using LinearAlgebra
 using PDMats
 using Random
 
-export BayesQuad, PriorSampling, BayesModel
+export BayesQuad, LogBayesQuad
+export PriorSampling, BayesModel
 export prior, integrand, logintegrand, logprior, logjoint
 
-abstract type AbstractBayesQuad end
+abstract type AbstractBayesQuad{Kernel, T} end
 abstract type AbstractBayesQuadModel{Tp, Ti} <: AbstractMCMC.AbstractModel end
 
 include(joinpath("bayesquads", "bayesquads.jl"))

--- a/src/bayesquads/bayesquads.jl
+++ b/src/bayesquads/bayesquads.jl
@@ -1,1 +1,25 @@
 include("bayesquad.jl")
+include("logbayesquad.jl")
+
+function kernel(b::AbstractBayesQuad)
+    return b.σ * transform(b.kernel, inv.(b.l))
+end
+
+function kernel(b::AbstractBayesQuad{<:Kernel,<:LowerTriangular})
+    return b.σ * transform(b.kernel, LinearTransform(inv(b.l)))
+end
+
+Λ(bquad::AbstractBayesQuad{<:SqExponentialKernel,<:Real}) = abs2(bquad.l) * I
+Λ(bquad::AbstractBayesQuad{<:SqExponentialKernel,<:AbstractVector}) = Diagonal(abs2.(bquad.l))
+Λ(bquad::AbstractBayesQuad{<:SqExponentialKernel,<:LowerTriangular}) = bquad.l * bquad.l'
+
+scale(bquad::AbstractBayesQuad) = bquad.σ
+lengthscale(bquad::AbstractBayesQuad) = bquad.l
+
+function evaluate_mean(z, K, y)
+    return dot(z, K \ y)
+end
+
+function evaluate_var(z, K, C)
+    return C - PDMats.invquad(K, z)
+end

--- a/src/bayesquads/logbayesquad.jl
+++ b/src/bayesquads/logbayesquad.jl
@@ -1,0 +1,98 @@
+"""
+    LogBayesQuad(k::Kernel; l=1.0, σ::Real=1.0)
+
+Bayesian Quadrature object.
+You can pass any kernel and the lengthscale and variance will be extracted.
+`l` can be a `Real`, a `AbstractVector` or a `LowerTriangular`.
+"""
+struct LogBayesQuad{TK,Tl,Tσ} <: AbstractBayesQuad{TK, Tl}
+    kernel::TK
+    n_candidates::Int
+    l::Tl
+    σ::Tσ
+end
+
+function LogBayesQuad(k::Kernel; n_candidates=100, l=1.0, σ::Real=1.0)
+    σ > 0 || ArgumentError("σ should be positive")
+    l isa AbstractMatrix && (
+        l isa LowerTriangular || throw(
+            ArgumentError(
+                "For l an AbstractMatrix, only LowerTriangular matrices are accepted"
+            ),
+        )
+    )
+    return LogBayesQuad(k, n_candidates, l, σ)
+end
+
+function LogBayesQuad(k::TransformedKernel{TK,Tt}; l=nothing, σ=1.0) where {TK,Tt}
+    Tt <: Union{ScaleTransform,ARDTransform,LinearTransform} ||
+        error("No lengthscale could be extracted from kernel $k,\n
+        only ScaleTransform, ARDTransform and LinearTransform are allowed")
+    l = param(k.transform)
+
+    return LogBayesQuad(k.kernel; l=l, σ=σ)
+end
+
+function LogBayesQuad(k::ScaledKernel; l=1.0, σ=nothing)
+    σ = first(k.σ²)
+    return LogBayesQuad(k.kernel; l=l, σ=σ)
+end
+
+function quadrature(
+    bquad::LogBayesQuad{<:SqExponentialKernel},
+    model::AbstractBayesQuadModel{<:MvNormal},
+    samples,
+)
+    isempty(samples) && error("The collection of samples is empty")
+    nsamples = length(samples)
+    x_c = sample_candidates(bquad, samples)
+    logf = logintegrand(model).(samples)
+    f = exp.(logf)
+    # f_c = integrand(model).(x_c)
+    # logf_c = logintegrand(model).(x_c)
+    joint_samples = vcat(samples, x_c)
+
+    fullK = kernelpdmat(kernel(bquad), joint_samples)
+    K = fullK[1:nsamples, 1:nsamples]
+    Kcx = fullK[(nsamples+1):end, 1:nsamples]
+    Kc = fullK[(nsamples+1):end, (nsamples+1):end]
+    κ = Kcx / Kc
+
+    f_c_0 = κ * f # 
+    f_c_0 = mean.(predict(bquad, samples, f, x_c))
+    logf_c_0 = κ * logf 
+    logf_c_0 = mean.(predict(bquad, samples, logf, x_c))
+    Δ_c = exp.(logf_c_0) - f_c_0
+    
+    z = calc_z(samples, prior(model), bquad)
+    K = kernelpdmat(kernel(bquad), samples)
+    C = calc_C(prior(model), bquad)
+    
+    z_c = calc_z(x_c, prior(model), bquad)
+    K_c = kernelpdmat(kernel(bquad), x_c)
+    @show Δ_c
+    @show m_evidence = evaluate_mean(z, K, f)
+    # @show m_correction = evaluate_mean(z_c, K_c, vcat(zeros(length(samples)), Δ_c))
+    @show m_correction = evaluate_mean(z_c, K_c, Δ_c)
+
+    @show var_evidence = evaluate_var(z, K, C)
+    @show var_correction = evaluate_var(z_c, K_c, C)
+    return Normal(m_evidence + m_correction, var_evidence + var_correction)
+end
+
+function predict(bquad::LogBayesQuad, samples, f, x_c)
+    gp = GP(kernel(bquad))
+    fx = gp(samples)
+    f_post = posterior(fx, f)
+    return f_c = mean(f_post(x_c)) 
+end
+
+function sample_candidates(bquad::LogBayesQuad, samples)
+    n_c = bquad.n_candidates
+    n_samples = length(samples)
+    n_dim = length(first(samples))
+    directions = [rand(n_dim) .- 0.5 |> x -> x / norm(x, 1) for _ in 1:n_c]
+    directions = lengthscale(bquad) .* directions
+    p_indices = rand(1:n_samples, n_c)
+    return directions .+= samples[p_indices] 
+end

--- a/src/kernelmeans/sekernel.jl
+++ b/src/kernelmeans/sekernel.jl
@@ -1,4 +1,4 @@
-function calc_z(samples, prior, bquad::BayesQuad{<:SqExponentialKernel})
+function calc_z(samples, prior, bquad::AbstractBayesQuad{<:SqExponentialKernel})
     D = length(prior)
     z = samples .- Ref(mean(prior))
     B = Λ(bquad)
@@ -6,7 +6,7 @@ function calc_z(samples, prior, bquad::BayesQuad{<:SqExponentialKernel})
            exp.(-0.5 * PDMats.quad.(Ref(PDMat(inv(B + cov(prior)))), samples))
 end
 
-function calc_C(prior, bquad::BayesQuad{<:SqExponentialKernel})
+function calc_C(prior, bquad::AbstractBayesQuad{<:SqExponentialKernel})
     D = length(prior)
     B = Λ(bquad)
     return scale(bquad) / sqrt(det(2 * inv(B) * cov(prior) + I))

--- a/test/bayesquads/logbayesquad.jl
+++ b/test/bayesquads/logbayesquad.jl
@@ -1,0 +1,10 @@
+using BayesianQuadrature
+using KernelFunctions
+using Distributions
+p_0 = MvNormal(ones(2)) # As for now the prior must be a MvNormal
+log_f(x) = logpdf(MvNormal(0.5 * ones(2)), x) # The logarithm of the Integrand log_f, the log-likelihood function typically
+model = BayesModel(p_0, log_f) # Combine both to create the model
+bquad = LogBayesQuad(SEKernel(); l=0.1, σ=1.0) # Will simply approximate p(y|x) with a GP (only works with SEKernel for now
+sampler = PriorSampling() # Will sample from the prior p_0
+p_I, _ = bquad(model, sampler; nsamples=100) # Returns a Normal distribution
+@show p_I # Normal{Float64}(μ=0.07063602778449946, σ=0.0028050929209120458)


### PR DESCRIPTION
Base on the idea that we should approximate `log(integrand(x))` instead of `integrand(x)`
See : [Osborne, M. et al. Active Learning of Model Evidence Using Bayesian Quadrature. in Advances in Neural Information Processing Systems 2012.](http://papers.nips.cc/paper/4657-active-learning-of-model-evidence-using-bayesian-quadrature.pdf)
